### PR TITLE
Allow using SelectorDOM on existing DOMDocument object

### DIFF
--- a/selector.inc
+++ b/selector.inc
@@ -16,11 +16,14 @@ define('SELECTOR_VERSION', '1.1.3');
  */
 
 class SelectorDOM {
-  public function SelectorDOM($html) {
-    $this->html = $html;
-    $this->dom = new DOMDocument();
-    @$this->dom->loadHTML($html);
-    $this->xpath = new DOMXpath($this->dom);
+  public function SelectorDOM($data) {
+    if ($data instanceof DOMDocument) {
+        $this->xpath = new DOMXpath($data);
+    } else {
+        $dom = new DOMDocument();
+        @$dom->loadHTML($data);
+        $this->xpath = new DOMXpath($dom);
+    }
   }
   
   public function select($selector, $as_array = true) {


### PR DESCRIPTION
Instead of creating a new DOMDocument, allow passing of DOMDocument object. In this way the returned nodes will reference the original document. Also removed saving the $html and $dom as instance variables, since they are not used
