### PR TITLE
noticket: fixing issue with attributes that had spaces in their values

### DIFF
--- a/selector.inc
+++ b/selector.inc
@@ -89,8 +89,8 @@ function selector_to_xpath($selector) {
   $selector = preg_replace('/\s*~\s*/', '~', $selector);
   $selector = preg_replace('/\s*\+\s*/', '+', $selector);
   $selector = preg_replace('/\s*,\s*/', ',', $selector);
-  $selectors = preg_split("/\s+/", $selector);
- 
+  $selectors = preg_split("/\s+(?![^\[]+\])/", $selector);
+
   foreach ($selectors as &$selector) {
   	// ,
   	$selector = preg_replace('/\s*,\s*/', '|descendant-or-self::', $selector);

--- a/test.selector.php
+++ b/test.selector.php
@@ -28,6 +28,8 @@ test('.foo',                'descendant-or-self::*[contains(concat(" ",@class," 
 test('[id]',                'descendant-or-self::*[@id]');
 test('[id=bar]',            'descendant-or-self::*[@id="bar"]');
 test('foo[id=bar]',         'descendant-or-self::foo[@id="bar"]');
+test('[style=color: red; border: 1px solid black;]',            'descendant-or-self::*[@style="color: red; border: 1px solid black;"]');
+test('foo[style=color: red; border: 1px solid black;]',         'descendant-or-self::foo[@style="color: red; border: 1px solid black;"]');
 test(':button',             'descendant-or-self::input[@type="button"]');
 test('textarea',            'descendant-or-self::textarea');
 test(':submit',             'descendant-or-self::input[@type="submit"]');


### PR DESCRIPTION
I had the need of accessing an element that had an ugly dom. So by the harcoded color was the only way to get it. 
The tool was splitting by spaces. I fixed the regular expression to do it only if not inside brackets, since that it would be allowed as part of the content of a bracket / value of the attribute.

See the test for an example.

Thanls
